### PR TITLE
Drop traceparent header at the APIM proxy

### DIFF
--- a/proxies/live/apiproxy/policies/AssignMessage.RemoveTraceParentHeader.xml
+++ b/proxies/live/apiproxy/policies/AssignMessage.RemoveTraceParentHeader.xml
@@ -1,0 +1,7 @@
+<AssignMessage async="false" continueOnError="true" enabled="true" name="AssignMessage.RemoveTraceParentHeader">
+  <Remove>
+    <Headers>
+      <Header name='traceparent'/>
+    </Headers>
+  </Remove>
+</AssignMessage>

--- a/proxies/live/apiproxy/targets/target.xml
+++ b/proxies/live/apiproxy/targets/target.xml
@@ -2,10 +2,13 @@
   <PreFlow>
     <Request>
       <Step>
+        AssignMessage.RemoveTraceParentHeader
+      </Step>
+      <Step>
         <Name>OauthV2.VerifyAccessToken</Name>
       </Step>
       <Step>
-          <Name>AssignMessage.AddIdTokenHeader</Name>
+        <Name>AssignMessage.AddIdTokenHeader</Name>
       </Step>
       <Step>
         <Name>FlowCallout.ApplyRateLimiting</Name>

--- a/proxies/sandbox/apiproxy/policies/AssignMessage.RemoveTraceParentHeader.xml
+++ b/proxies/sandbox/apiproxy/policies/AssignMessage.RemoveTraceParentHeader.xml
@@ -1,0 +1,7 @@
+<AssignMessage async="false" continueOnError="true" enabled="true" name="AssignMessage.RemoveTraceParentHeader">
+  <Remove>
+    <Headers>
+      <Header name='traceparent'/>
+    </Headers>
+  </Remove>
+</AssignMessage>

--- a/proxies/sandbox/apiproxy/proxies/default.xml
+++ b/proxies/sandbox/apiproxy/proxies/default.xml
@@ -23,6 +23,9 @@
     <Flow name="StatusEndpoint">
       <Request>
         <Step>
+          AssignMessage.RemoveTraceParentHeader
+        </Step>
+        <Step>
           <Condition>request.header.apikey = null or private.common.status-endpoint-api-key != request.header.apikey</Condition>
           <Name>RaiseFault.401Unauthorized</Name>
         </Step>


### PR DESCRIPTION
## Summary
 :robot:  :warning: Removes upstream traceparent headers that might interfere with AWS XRay OpenTelemetry instrumentation

This supports a change to simplify Aggregator Ingress (removing a L7 proxy that previously performed these duties)

## Reviews Required
* [x] Dev
* [x] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
