### PR TITLE
WPP-10854:Aligned spec for Consultation Medium with Aggreagtor code behaviour, …

### DIFF
--- a/specification/components/examples/GetAppointmentResponseHappyPath.json
+++ b/specification/components/examples/GetAppointmentResponseHappyPath.json
@@ -21,7 +21,7 @@
         "valueCode": "Pending Reschedule"
       }, {
         "url": "https://fhir.nhs.uk/StructureDefinition/Extension-Consultation-Medium",
-        "valueCode": "VIRTUAL"
+        "valueCode": "VIDEO_CONSULTATION"
       }, {
         "url": "https://fhir.nhs.uk/StructureDefinition/Extension-Portal-Link",
         "valueUrl": "https://my.patientportal.co.uk/Appointment/d9df1326-1008-45df-b9dd-a920b64ec043"

--- a/specification/patient-care-aggregator-api-consumer-api.yaml
+++ b/specification/patient-care-aggregator-api-consumer-api.yaml
@@ -757,7 +757,7 @@ components:
                               - bookedPendingReschedule
                               - bookedPendingChange
                               - cancelledPendingReschedule
-                  - description: The consultation medium for the booking (face-to-face, telephone or video call). Always present if the activity is a booking, but might be blank if the underlying consultation type is not recognised. VIRTUAL is now deprecated, but remains in the API for backward compatibility reasons, so it might still be passed by systems integrated with the Aggregator.
+                  - description: The consultation medium for the booking (face-to-face, telephone or video call). Only present if the underlying consultation type is recognised.
                     type: object
                     required:
                       - url
@@ -769,11 +769,10 @@ components:
                         enum:
                           - https://fhir.nhs.uk/StructureDefinition/Extension-Consultation-Medium
                       valueCode:
-                        description: The consultation code medium itself. Will be blank (empty string) if the underlying consultation type is not recognised.
+                        description: The consultation code medium itself, only set if the underlying consultation type is recognised.
                         type: string
                         enum:
                           - FACE_TO_FACE
-                          - VIRTUAL
                           - VIDEO_CONSULTATION
                           - TELEPHONE
                   - description: Encounter class element

--- a/specification/patient-care-aggregator-api-consumer-api.yaml
+++ b/specification/patient-care-aggregator-api-consumer-api.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Wayfinder Patient Care Aggregator API
-  version: v3.10.0
+  version: v3.11.0
   description: |
     <div class="nhsd-m-emphasis-box nhsd-m-emphasis-box--emphasis nhsd-!t-margin-bottom-6" aria-label="Highlighted Information">
         <div class="nhsd-a-box nhsd-a-box--border-blue">
@@ -769,7 +769,7 @@ components:
                         enum:
                           - https://fhir.nhs.uk/StructureDefinition/Extension-Consultation-Medium
                       valueCode:
-                        description: The consultation code medium itself, only set if the underlying consultation type is recognised.
+                        description: The consultation medium code itself, only set if the underlying consultation type is recognised.
                         type: string
                         enum:
                           - FACE_TO_FACE
@@ -1471,12 +1471,12 @@ components:
               $ref: "#/components/examples/appointmentFuturePepCancelledPendingReschedule"
             appointmentFuturePepFaceToFace:
               $ref: "#/components/examples/appointmentFuturePepFaceToFace"
-            appointmentFuturePepVirtual:
-              $ref: "#/components/examples/appointmentFuturePepVirtual"
+            appointmentFuturePepVideoConsultation:
+              $ref: "#/components/examples/appointmentFuturePepVideoConsultation"
             appointmentHistoricPepFaceToFace:
               $ref: "#/components/examples/appointmentHistoricPepFaceToFace"
-            appointmentHistoricPepVirtual:
-              $ref: "#/components/examples/appointmentHistoricPepVirtual"
+            appointmentHistoricPepVideoConsultation:
+              $ref: "#/components/examples/appointmentHistoricPepVideoConsultation"
             appointmentHistoricSusAttended:
               $ref: "#/components/examples/appointmentHistoricSusAttended"
             appointmentHistoricSusCancelled:
@@ -1803,9 +1803,9 @@ components:
                 - $ref: "#/components/examples/correspondenceReadLinked"
                 - $ref: "#/components/examples/appointmentFuturePepFaceToFace"
                 - $ref: "#/components/examples/correspondenceReadLinked"
-                - $ref: "#/components/examples/appointmentFuturePepVirtual"
+                - $ref: "#/components/examples/appointmentFuturePepVideoConsultation"
                 - $ref: "#/components/examples/appointmentHistoricPepFaceToFace"
-                - $ref: "#/components/examples/appointmentHistoricPepVirtual"
+                - $ref: "#/components/examples/appointmentHistoricPepVideoConsultation"
                 - $ref: "#/components/examples/appointmentHistoricSusAttended"
                 - $ref: "#/components/examples/appointmentHistoricSusCancelled"
                 - $ref: "#/components/examples/appointmentHistoricSusDNA"
@@ -2982,7 +2982,7 @@ components:
                 system: http://hl7.org/fhir/appointmentstatus
                 code: bookedPendingCancellation
             - url: https://fhir.nhs.uk/StructureDefinition/Extension-Consultation-Medium
-              valueCode: VIRTUAL
+              valueCode: VIDEO_CONSULTATION
             - url: https://fhir.nhs.uk/StructureDefinition/Extension-Encounter-Class
               valueCode: outpatient
           description: Gastroenterology
@@ -3074,7 +3074,7 @@ components:
                 system: http://hl7.org/fhir/appointmentstatus
                 code: cancelledPendingReschedule
             - url: https://fhir.nhs.uk/StructureDefinition/Extension-Consultation-Medium
-              valueCode: VIRTUAL
+              valueCode: VIDEO_CONSULTATION
             - url: https://fhir.nhs.uk/StructureDefinition/Extension-Encounter-Class
               valueCode: outpatient
           description: Cardiology Service
@@ -3154,8 +3154,8 @@ components:
                 system: https://fhir.nhs.uk/Id/ods-organization-code
                 value: 'RCX'
               display: THE QUEEN ELIZABETH HOSPITAL, KING'S LYNN, NHS FOUNDATION
-    appointmentFuturePepVirtual:
-      summary: Fragment - Future booked Appointment from a PEP, virtual
+    appointmentFuturePepVideoConsultation:
+      summary: Fragment - Future booked Appointment from a PEP, video consultation
       value:
         detail:
           id: 2c48ec66-2e84-407a-b9a1-6c42c4e8969a
@@ -3171,7 +3171,7 @@ components:
                 system: http://hl7.org/fhir/appointmentstatus
                 code: booked
             - url: https://fhir.nhs.uk/StructureDefinition/Extension-Consultation-Medium
-              valueCode: VIRTUAL
+              valueCode: VIDEO_CONSULTATION
             - url: https://fhir.nhs.uk/StructureDefinition/Extension-Encounter-Class
               valueCode: outpatient
           description: Oral Maxillo-Facial Surgery
@@ -3218,8 +3218,8 @@ components:
                 system: https://fhir.nhs.uk/Id/ods-organization-code
                 value: 'RR8'
               display: LEEDS TEACHING HOSPITALS NHS TRUST
-    appointmentHistoricPepVirtual:
-      summary: Fragment - Historic attended Appointment from a PEP, virtual
+    appointmentHistoricPepVideoConsultation:
+      summary: Fragment - Historic attended Appointment from a PEP, video consultation
       value:
         detail:
           id: 9f30c28b-c2f6-4e88-bcec-0b2c17f80b87
@@ -3235,7 +3235,7 @@ components:
                 system: http://hl7.org/fhir/appointmentstatus
                 code: fulfilled
             - url: https://fhir.nhs.uk/StructureDefinition/Extension-Consultation-Medium
-              valueCode: VIRTUAL
+              valueCode: VIDEO_CONSULTATION
             - url: https://fhir.nhs.uk/StructureDefinition/Extension-Encounter-Class
               valueCode: outpatient
           description: Dermatology
@@ -3295,7 +3295,7 @@ components:
                 system: http://hl7.org/fhir/appointmentstatus
                 code: cancelled
             - url: https://fhir.nhs.uk/StructureDefinition/Extension-Consultation-Medium
-              valueCode: VIRTUAL
+              valueCode: VIDEO_CONSULTATION 
             - url: https://fhir.nhs.uk/StructureDefinition/Extension-Encounter-Class
               valueCode: outpatient
           description: Gastroenterology

--- a/specification/patient-care-aggregator-api-producer-api-standards.yaml
+++ b/specification/patient-care-aggregator-api-producer-api-standards.yaml
@@ -404,7 +404,7 @@ components:
                       - Pending Reschedule 
                       - Pending Cancellation 
                       - Confirmed Attendance                                
-              - description: "Consultation medium - whether the appointment is face-to-face, on the telephone or via an online video consultation (required). VIRTUAL is now deprecated and only remains in the API spec for backwards compatibility reasons."
+              - description: "Consultation medium - whether the appointment is face-to-face, on the telephone or via an online video consultation (required). VIRTUAL is now deprecated, it will be filtered and removed from responses, along with any other values not listed."
                 type: object
                 required:
                   - url
@@ -420,7 +420,6 @@ components:
                     description: The consultation medium itself.
                     enum:
                       - "FACE_TO_FACE"
-                      - "VIRTUAL"
                       - "VIDEO_CONSULTATION"
                       - "TELEPHONE"
               - description: "Deep link URL to appointment in portal system (required)."

--- a/specification/patient-care-aggregator-api-producer-api-standards.yaml
+++ b/specification/patient-care-aggregator-api-producer-api-standards.yaml
@@ -3,7 +3,7 @@
 openapi: '3.0.3'
 info:
   title: "Patient Care Aggregator Get Appointments, Documents and Questionnaires API Standard"
-  version: "3.11.0"
+  version: "3.12.0"
   description: |
     ## Overview 
     ![Patient Care Aggregator Get Appointments, Documents and Questionnaires API Standard context diagram](https://digital.nhs.uk/binaries/content/gallery/website/developer/api-catalogue/patient-care-aggregator-fhir-api/patient-care-aggregator-get-appointments-api-standard.svg?raw=true)
@@ -404,7 +404,7 @@ components:
                       - Pending Reschedule 
                       - Pending Cancellation 
                       - Confirmed Attendance                                
-              - description: "Consultation medium - whether the appointment is face-to-face, on the telephone or via an online video consultation (required). VIRTUAL is now deprecated, it will be filtered and removed from responses, along with any other values not listed."
+              - description: "Consultation medium - whether the appointment is face-to-face, on the telephone or via an online video consultation (required). VIRTUAL is now deprecated, it will be filtered and removed from PEP responses by Aggregator, along with any other values not listed."
                 type: object
                 required:
                   - url
@@ -1588,7 +1588,7 @@ components:
                 - url: "https://fhir.nhs.uk/StructureDefinition/Extension-Appointment-RequestStatus"
                   valueCode: "Pending Reschedule"
                 - url: "https://fhir.nhs.uk/StructureDefinition/Extension-Consultation-Medium"
-                  valueCode: "VIRTUAL"
+                  valueCode: "VIDEO_CONSULTATION"
                 - url: "https://fhir.nhs.uk/StructureDefinition/Extension-Portal-Link"
                   valueUrl: "https://my.patientportal.co.uk/Appointment/d9df1326-1008-45df-b9dd-a920b64ec043"
               identifier:


### PR DESCRIPTION

## Summary 

* Routine Change - [WPP-10854](https://nhsd-jira.digital.nhs.uk/browse/WPP-10854)

Associated Aggregator code change details [WPP-10569](https://nhsd-jira.digital.nhs.uk/browse/WPP-10569) and [PR 433](https://github.com/NHSDigital/patient-care-aggregator.core/pull/433)

Updated the Producer and Consumer spec to align to agreed behaviour with SCS team.

Removing the redundant VIRTUAL valueCode,  VIRTUAL" will be accepted from PEPs but treated as invalid for downstream purposes, it will be filtered out by the Aggregator and not included in the response to the App. Only valid Consultation Mediums will cause the object to be present in response rather than passing empty strings for invalid values.
Only the following values will be passed through to the App: FACE_TO_FACE, VIDEO_CONSULTATION, TELEPHONE

## Reviews Required
* [x] Dev
* [x] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [x] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [x] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
